### PR TITLE
Allow up to 8192 rows to fail before failing the overall ingest

### DIFF
--- a/core/src/main/scala/quasar/physical/ts/TSDestination.scala
+++ b/core/src/main/scala/quasar/physical/ts/TSDestination.scala
@@ -163,6 +163,7 @@ final class TSDestination[F[_]: Concurrent: ContextShift: MonadResourceErr] priv
     | tsload
     |   --target_database '${config.database}'
     |   --target_table '$tableName'
+    |   --max_ignored_rows 8192
     |   --field_separator ','
     |   --null_value ''
     |   --date_time_format '${TSTimePatterns.LocalDateTime}'


### PR DESCRIPTION
Frankly, I'm not so sure this is a great idea. We can use it as a shim to prevent demos from exploding spectacularly as we nail down some of the remaining things (like string width), but I'd rather just fail immediately if a row is failing. @beckyconning wdyt?

[ch9212]